### PR TITLE
[feat/#11] 마이페이지 구현 #11

### DIFF
--- a/src/main/java/servnow/servnow/api/user/controller/UserController.java
+++ b/src/main/java/servnow/servnow/api/user/controller/UserController.java
@@ -1,15 +1,29 @@
 package servnow.servnow.api.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import servnow.servnow.api.advice.ResponseAdvice;
+import servnow.servnow.api.dto.ServnowResponse;
+import servnow.servnow.api.user.controller.response.MyPageResponse;
 import servnow.servnow.api.user.service.UserCommandService;
 import servnow.servnow.api.user.service.UserQueryService;
+import servnow.servnow.common.code.CommonSuccessCode;
+import servnow.servnow.domain.user.model.User;
+import servnow.servnow.domain.user.model.UserInfo;
 
 @RestController
 @RequestMapping("/api/v1")
 @RequiredArgsConstructor
 public class UserController {
-  private final UserCommandService userCommandService;
-  private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
+
+
+    // 아직 유저 정보를 넘기는 방식이 정해지지 않아서 UserQueryService에서 userId값을 고정하여 테스트 함
+    @GetMapping("/users/me")
+    public ServnowResponse<MyPageResponse> getMyPage() {
+        return ServnowResponse.success(CommonSuccessCode.OK, userQueryService.getMyPage());
+    }
 }

--- a/src/main/java/servnow/servnow/api/user/controller/response/MyPageResponse.java
+++ b/src/main/java/servnow/servnow/api/user/controller/response/MyPageResponse.java
@@ -1,0 +1,21 @@
+    package servnow.servnow.api.user.controller.response;
+
+    import servnow.servnow.domain.user.model.User;
+    import servnow.servnow.domain.user.model.UserInfo;
+    import servnow.servnow.domain.user.model.enums.Level;
+
+    public record MyPageResponse(
+            String nickname,
+            String profileUrl,
+            int point,
+            Level level,
+            int userCreatedSurveyCount,
+            int userParticipatedSurveyCount
+    ) {
+
+        public static MyPageResponse of(UserInfo userInfo, User user) {
+            return new MyPageResponse(userInfo.getNickname(), userInfo.getProfile_url(), userInfo.getPoint(), userInfo.getLevel(),
+                    user.getSurveys().size(), user.getSurveyResults().size());
+        }
+
+    }

--- a/src/main/java/servnow/servnow/api/user/service/UserQueryService.java
+++ b/src/main/java/servnow/servnow/api/user/service/UserQueryService.java
@@ -2,8 +2,27 @@ package servnow.servnow.api.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import servnow.servnow.api.user.controller.response.MyPageResponse;
+import servnow.servnow.common.code.UserErrorCode;
+import servnow.servnow.common.exception.NotFoundException;
+import servnow.servnow.domain.user.model.User;
+import servnow.servnow.domain.user.model.UserInfo;
+import servnow.servnow.domain.user.repository.UserInfoRepository;
+import servnow.servnow.domain.user.repository.UserRepository;
 
 @Service
 @RequiredArgsConstructor
 public class UserQueryService {
+    private final UserInfoRepository userInfoRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public MyPageResponse getMyPage() {
+        User user = userRepository.findById(3L)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+        UserInfo userinfo = userInfoRepository.findById(1L)
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+        return MyPageResponse.of(userinfo, user);
+    }
 }

--- a/src/main/java/servnow/servnow/common/code/UserErrorCode.java
+++ b/src/main/java/servnow/servnow/common/code/UserErrorCode.java
@@ -1,0 +1,17 @@
+package servnow.servnow.common.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 유저가 존재하지 않습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/servnow/servnow/domain/subjectiveresult/repository/SubjectiveResultRepository.java
+++ b/src/main/java/servnow/servnow/domain/subjectiveresult/repository/SubjectiveResultRepository.java
@@ -1,6 +1,7 @@
 package servnow.servnow.domain.subjectiveresult.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import servnow.servnow.domain.subjectiveresult.model.SubjectiveResult;
 
-public interface SubjectiveResultRepository extends JpaRepository<SubjectiveResultRepository, Long> {
+public interface SubjectiveResultRepository extends JpaRepository<SubjectiveResult, Long> {
 }

--- a/src/main/java/servnow/servnow/domain/user/repository/UserInfoRepository.java
+++ b/src/main/java/servnow/servnow/domain/user/repository/UserInfoRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import servnow.servnow.domain.user.model.UserInfo;
 
 public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
+
 }


### PR DESCRIPTION
<!-- 1. PR 제목 형식 : [type] #이슈번호-PR제목 -->
<!-- 2. 오른쪽에 태그 선택해주기(pr 대상, 작업 유형, 작업자)-->

-closes #11

# 구현 내용❗️
<!-- API 명세서, API Controller 등등 -->
<!-- 상세설명_ & 캡쳐 -->

# 요구사항 분석 ❗️

### 작업 내용 1
- 마이페이지에서 "프로필 이미지", "유저 닉네임", "등급", "포인트", "설문 제작 수", "설문 참여 수 반환"

# 구현 고민사항 ❗️

<!-- 이 부분은 코드를 직접 올려주면 다른 리뷰어들에게 도움이 될 것 같습니다. -->
```
 public MyPageResponse getMyPage() {
        User user = userRepository.findById(3L)
                .orElseThrow(() -> new NotFoundException(UserMyPageErrorCode.USER_NOT_FOUND));
        UserInfo userinfo = userInfoRepository.findById(1L)
                .orElseThrow(() -> new NotFoundException(UserMyPageErrorCode.USER_NOT_FOUND));
        return MyPageResponse.of(userinfo, user);
    }
```


### 고민사항 1
user에 대한 정보를 어떻게 받아올지 정해지지 않아서 고정 userId 값으로 테스트하였습니다.
추후에 user 정보에 대해서 정해지면 수정하겠습니다.

