### PR TITLE
[feat/#14] 설문조사 인트로 화면 API 

### DIFF
--- a/src/main/java/servnow/servnow/api/survey/controller/SurveyController.java
+++ b/src/main/java/servnow/servnow/api/survey/controller/SurveyController.java
@@ -2,14 +2,20 @@ package servnow.servnow.api.survey.controller;
 
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import servnow.servnow.api.dto.ServnowResponse;
 import servnow.servnow.api.survey.dto.request.SurveyPostRequest;
+import servnow.servnow.api.survey.dto.response.SurveyIntroGetResponse;
 import servnow.servnow.api.survey.service.SurveyCommandService;
+import servnow.servnow.api.survey.service.SurveyQueryService;
 import servnow.servnow.common.code.CommonSuccessCode;
 
 @RestController
@@ -18,11 +24,18 @@ import servnow.servnow.common.code.CommonSuccessCode;
 public class SurveyController {
 
   private final SurveyCommandService surveyCommandService;
+  private final SurveyQueryService surveyQueryService;
+
 
   @PostMapping("/survey")
   public ServnowResponse<Void> createSurvey(@RequestBody @Valid SurveyPostRequest surveyPostRequest) {
     // 유저 임시생성, 추후 아이디 로직 머지 후 고칠 예정
     surveyCommandService.createSurvey(1L, surveyPostRequest);
     return ServnowResponse.success(CommonSuccessCode.CREATED);
+  }
+
+  @GetMapping("/survey/{id}/intro")
+  public ServnowResponse<SurveyIntroGetResponse> getSurveyIntro(@PathVariable(name = "id") long id) {
+    return ServnowResponse.success(CommonSuccessCode.OK, surveyQueryService.getSurveyIntro(null, id));
   }
 }

--- a/src/main/java/servnow/servnow/api/survey/controller/SurveyController.java
+++ b/src/main/java/servnow/servnow/api/survey/controller/SurveyController.java
@@ -36,6 +36,7 @@ public class SurveyController {
 
   @GetMapping("/survey/{id}/intro")
   public ServnowResponse<SurveyIntroGetResponse> getSurveyIntro(@PathVariable(name = "id") long id) {
-    return ServnowResponse.success(CommonSuccessCode.OK, surveyQueryService.getSurveyIntro(null, id));
+    // 유저 임시생성, 추후 아이디 로직 머지 후 고칠 예정
+    return ServnowResponse.success(CommonSuccessCode.OK, surveyQueryService.getSurveyIntro(1L, id));
   }
 }

--- a/src/main/java/servnow/servnow/api/survey/dto/response/SurveyIntroGetResponse.java
+++ b/src/main/java/servnow/servnow/api/survey/dto/response/SurveyIntroGetResponse.java
@@ -1,0 +1,34 @@
+package servnow.servnow.api.survey.dto.response;
+
+import java.time.LocalDateTime;
+import servnow.servnow.domain.survey.model.Survey;
+import servnow.servnow.domain.survey.model.enums.CharacterType;
+
+public record SurveyIntroGetResponse(
+    boolean isRegisteredUser,
+    int duration,
+    int questionCount,
+    CharacterType characterType,
+    String reward,
+    Integer rewardCount,
+    String title,
+    String content1,
+    String content2,
+    LocalDateTime createdAt,
+    LocalDateTime expiredAt
+) {
+  public static SurveyIntroGetResponse of(final Survey survey, final boolean isRegistered, final int questionCount) {
+    return new SurveyIntroGetResponse(
+        isRegistered,
+        Math.round((float) survey.getDuration() / 60),
+        questionCount,
+        survey.getCharacterType(),
+        survey.getReward(),
+        survey.getRewardCount(),
+        survey.getTitle(),
+        survey.getContent1(),
+        survey.getContent2(),
+        survey.getCreatedAt(),
+        survey.getExpiredAt());
+  }
+}

--- a/src/main/java/servnow/servnow/api/survey/service/SurveyFinder.java
+++ b/src/main/java/servnow/servnow/api/survey/service/SurveyFinder.java
@@ -1,0 +1,19 @@
+package servnow.servnow.api.survey.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import servnow.servnow.common.code.SurveyErrorCode;
+import servnow.servnow.common.exception.NotFoundException;
+import servnow.servnow.domain.survey.model.Survey;
+import servnow.servnow.domain.survey.repository.SurveyRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SurveyFinder {
+
+  private final SurveyRepository surveyRepository;
+
+  public Survey findByIdWithSectionsAndQuestions(final long id) {
+    return surveyRepository.findByIdWithSections(id).orElseThrow(() -> new NotFoundException(SurveyErrorCode.SURVEY_NOT_FOUND));
+  }
+}

--- a/src/main/java/servnow/servnow/api/survey/service/SurveyQueryService.java
+++ b/src/main/java/servnow/servnow/api/survey/service/SurveyQueryService.java
@@ -2,8 +2,25 @@ package servnow.servnow.api.survey.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import servnow.servnow.api.survey.dto.response.SurveyIntroGetResponse;
+import servnow.servnow.domain.survey.model.Survey;
 
 @Service
 @RequiredArgsConstructor
 public class SurveyQueryService {
+
+  private final SurveyFinder surveyFinder;
+
+  @Transactional(readOnly = true)
+  public SurveyIntroGetResponse getSurveyIntro(final Long userId, final long id) {
+    Survey survey = surveyFinder.findByIdWithSectionsAndQuestions(id);
+    return SurveyIntroGetResponse.of(survey, (userId != null), countQuestion(survey));
+  }
+
+  private int countQuestion(final Survey survey) {
+    return survey.getSections().stream()
+        .mapToInt(section -> section.getQuestions().size())
+        .sum();
+  }
 }

--- a/src/main/java/servnow/servnow/common/code/SurveyErrorCode.java
+++ b/src/main/java/servnow/servnow/common/code/SurveyErrorCode.java
@@ -1,0 +1,15 @@
+package servnow.servnow.common.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SurveyErrorCode implements ErrorCode {
+
+  SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 설문이 존재하지 않습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+}

--- a/src/main/java/servnow/servnow/domain/common/BaseTimeEntity.java
+++ b/src/main/java/servnow/servnow/domain/common/BaseTimeEntity.java
@@ -4,12 +4,14 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseTimeEntity {
 
   @CreatedDate

--- a/src/main/java/servnow/servnow/domain/section/model/Section.java
+++ b/src/main/java/servnow/servnow/domain/section/model/Section.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import servnow.servnow.domain.common.BaseTimeEntity;
 import servnow.servnow.domain.question.model.Question;
 import servnow.servnow.domain.survey.model.Survey;
@@ -41,6 +42,7 @@ public class Section extends BaseTimeEntity {
     private int nextSectionNo;
 
     @OneToMany(mappedBy = "section")
+    @BatchSize(size = 100)
     private List<Question> questions = new ArrayList<>();
 
     public static Section create(Survey survey, int sectionOrder, String title, String content, int nextSectionNo) {

--- a/src/main/java/servnow/servnow/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/servnow/servnow/domain/survey/repository/SurveyRepository.java
@@ -1,8 +1,13 @@
 package servnow.servnow.domain.survey.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import servnow.servnow.domain.survey.model.Survey;
 
 public interface SurveyRepository extends JpaRepository<Survey, Long> {
 
+  @Query("select s from Survey s join fetch s.sections sec where s.id = :id")
+  Optional<Survey> findByIdWithSections(@Param("id") long id);
 }


### PR DESCRIPTION
-closes #14 

# 구현 내용❗️

# 요구사항 분석 ❗️
설문조사 인트로 화면 API 

### 작업 내용 1

- 가입된 멤버에 따라 화면 다름 -> 구분해줌

### 작업 내용 2

- postman test 완료

```json
{
    "code": 200,
    "message": "요청이 성공했습니다(200).",
    "data": {
        "isRegisteredUser": false,
        "duration": 2,
        "questionCount": 4,
        "characterType": "TYPE_ONE",
        "reward": "스벅",
        "rewardCount": 10,
        "title": "설문지 제목",
        "content1": "ㄹㄹㄹ",
        "content2": "설명2",
        "createdAt": "2024-08-03T16:00:45.255437",
        "expiredAt": "2024-08-02T22:02:06.989625"
    }
}
```



# 구현 고민사항 ❗️

N/A
