### PR TITLE
[feat/#13] 설문조사 조회 화면 API (섹션별)

### DIFF
--- a/src/main/java/servnow/servnow/api/section/service/SectionFinder.java
+++ b/src/main/java/servnow/servnow/api/section/service/SectionFinder.java
@@ -1,0 +1,23 @@
+package servnow.servnow.api.section.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import servnow.servnow.common.code.SectionErrorCode;
+import servnow.servnow.common.exception.NotFoundException;
+import servnow.servnow.domain.section.model.Section;
+import servnow.servnow.domain.section.repository.SectionRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SectionFinder {
+
+  private final SectionRepository sectionRepository;
+
+  public Section findBySurveyIdAndSectionOrderWithQuestions(final long surveyId, final int sectionOrder) {
+    return sectionRepository.findBySurveyIdAndSectionOrderWithQuestions(surveyId, sectionOrder).orElseThrow(() -> new NotFoundException(SectionErrorCode.SECTION_NOT_FOUND));
+  }
+
+  public long countBySurvey(final long surveyId) {
+    return sectionRepository.countBySurveyId(surveyId);
+  }
+}

--- a/src/main/java/servnow/servnow/api/section/service/SectionUpdater.java
+++ b/src/main/java/servnow/servnow/api/section/service/SectionUpdater.java
@@ -1,6 +1,5 @@
 package servnow.servnow.api.section.service;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import servnow.servnow.domain.section.model.Section;

--- a/src/main/java/servnow/servnow/api/survey/controller/SurveyController.java
+++ b/src/main/java/servnow/servnow/api/survey/controller/SurveyController.java
@@ -1,18 +1,16 @@
 package servnow.servnow.api.survey.controller;
 
 import jakarta.validation.Valid;
-import java.time.LocalDateTime;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import servnow.servnow.api.dto.ServnowResponse;
 import servnow.servnow.api.survey.dto.request.SurveyPostRequest;
+import servnow.servnow.api.survey.dto.response.SurveyGetResponse;
 import servnow.servnow.api.survey.dto.response.SurveyIntroGetResponse;
 import servnow.servnow.api.survey.service.SurveyCommandService;
 import servnow.servnow.api.survey.service.SurveyQueryService;
@@ -38,5 +36,11 @@ public class SurveyController {
   public ServnowResponse<SurveyIntroGetResponse> getSurveyIntro(@PathVariable(name = "id") long id) {
     // 유저 임시생성, 추후 아이디 로직 머지 후 고칠 예정
     return ServnowResponse.success(CommonSuccessCode.OK, surveyQueryService.getSurveyIntro(1L, id));
+  }
+
+  @GetMapping("/survey/{id}/sections/{sectionOrder}")
+  public ServnowResponse<SurveyGetResponse> getSurveySection(@PathVariable(name = "id") long surveyId, @PathVariable(name = "sectionOrder") int sectionOrder) {
+    // 유저 임시생성, 추후 아이디 로직 머지 후 고칠 예정
+    return ServnowResponse.success(CommonSuccessCode.OK, surveyQueryService.getSurveySection(surveyId, sectionOrder));
   }
 }

--- a/src/main/java/servnow/servnow/api/survey/controller/SurveyController.java
+++ b/src/main/java/servnow/servnow/api/survey/controller/SurveyController.java
@@ -40,7 +40,6 @@ public class SurveyController {
 
   @GetMapping("/survey/{id}/sections/{sectionOrder}")
   public ServnowResponse<SurveyGetResponse> getSurveySection(@PathVariable(name = "id") long surveyId, @PathVariable(name = "sectionOrder") int sectionOrder) {
-    // 유저 임시생성, 추후 아이디 로직 머지 후 고칠 예정
     return ServnowResponse.success(CommonSuccessCode.OK, surveyQueryService.getSurveySection(surveyId, sectionOrder));
   }
 }

--- a/src/main/java/servnow/servnow/api/survey/dto/request/SurveyPostRequest.java
+++ b/src/main/java/servnow/servnow/api/survey/dto/request/SurveyPostRequest.java
@@ -71,7 +71,7 @@ public record SurveyPostRequest(
     ) {
 
       public Question toEntity(final Section section) {
-        return Question.create(section, questionOrder, questionContent, questionType, isEssential,
+        return Question.create(section, questionOrder, questionTitle, questionContent, questionType, isEssential,
             isDuplicate, hasNextSection);
       }
 

--- a/src/main/java/servnow/servnow/api/survey/dto/response/SurveyGetResponse.java
+++ b/src/main/java/servnow/servnow/api/survey/dto/response/SurveyGetResponse.java
@@ -1,0 +1,74 @@
+package servnow.servnow.api.survey.dto.response;
+
+import java.util.List;
+import servnow.servnow.domain.question.model.MultipleChoice;
+import servnow.servnow.domain.question.model.Question;
+import servnow.servnow.domain.question.model.enums.QuestionType;
+import servnow.servnow.domain.section.model.Section;
+
+public record SurveyGetResponse(
+    long surveyId,
+    String sectionTitle,
+    String sectionContent,
+    int sectionOrder,
+    int sectionTotalCount,
+    int nextSectionNo,
+    List<SurveyGetQuestion> questions
+) {
+
+  public static SurveyGetResponse of(final Section section, final int sectionTotalCount) {
+    return new SurveyGetResponse(
+        section.getSurvey().getId(),
+        section.getTitle(),
+        section.getContent(),
+        section.getSectionOrder(),
+        sectionTotalCount,
+        section.getNextSectionNo(),
+        section.getQuestions().stream().map(SurveyGetQuestion::of).toList()
+        );
+  }
+
+  public record SurveyGetQuestion(
+      long questionId,
+      String questionTitle,
+      String questionContent,
+      int questionOrder,
+      QuestionType questionType,
+      boolean isEssential,
+      boolean isDuplicate,
+      boolean hasNextSection,
+      List<SurveyGetAnswer> answers
+  ){
+    public static SurveyGetQuestion of(final Question question) {
+      return new SurveyGetQuestion(
+          question.getId(),
+          question.getTitle(),
+          question.getContent(),
+          question.getQuestionOrder(),
+          question.getQuestionType(),
+          question.isEssential(),
+          question.isDuplicate(),
+          question.isHasNextSection(),
+          getMultipleChoicesOrNull(question));
+    }
+
+    private static List<SurveyGetAnswer> getMultipleChoicesOrNull(final Question question){
+        if (question.getQuestionType().equals(QuestionType.MULTIPLE_CHOICE)){
+          return question.getMultipleChoices().stream().map(SurveyGetAnswer::of).toList();
+        }
+        return null;
+    }
+
+    public record SurveyGetAnswer(
+      String answerContent,
+      Integer nextSectionNo
+    ) {
+      public static SurveyGetAnswer of(final MultipleChoice multipleChoice) {
+        return new SurveyGetAnswer(
+            multipleChoice.getContent(),
+            multipleChoice.getNextSectionNo()
+        );
+      }
+    }
+  }
+}

--- a/src/main/java/servnow/servnow/api/survey/dto/response/SurveyGetResponse.java
+++ b/src/main/java/servnow/servnow/api/survey/dto/response/SurveyGetResponse.java
@@ -49,14 +49,7 @@ public record SurveyGetResponse(
           question.isEssential(),
           question.isDuplicate(),
           question.isHasNextSection(),
-          getMultipleChoicesOrNull(question));
-    }
-
-    private static List<SurveyGetAnswer> getMultipleChoicesOrNull(final Question question){
-        if (question.getQuestionType().equals(QuestionType.MULTIPLE_CHOICE)){
-          return question.getMultipleChoices().stream().map(SurveyGetAnswer::of).toList();
-        }
-        return null;
+          question.getMultipleChoices().stream().map(SurveyGetAnswer::of).toList());
     }
 
     public record SurveyGetAnswer(

--- a/src/main/java/servnow/servnow/api/survey/service/SurveyQueryService.java
+++ b/src/main/java/servnow/servnow/api/survey/service/SurveyQueryService.java
@@ -3,6 +3,8 @@ package servnow.servnow.api.survey.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import servnow.servnow.api.section.service.SectionFinder;
+import servnow.servnow.api.survey.dto.response.SurveyGetResponse;
 import servnow.servnow.api.survey.dto.response.SurveyIntroGetResponse;
 import servnow.servnow.domain.survey.model.Survey;
 
@@ -11,11 +13,17 @@ import servnow.servnow.domain.survey.model.Survey;
 public class SurveyQueryService {
 
   private final SurveyFinder surveyFinder;
+  private final SectionFinder sectionFinder;
 
   @Transactional(readOnly = true)
   public SurveyIntroGetResponse getSurveyIntro(final Long userId, final long id) {
     Survey survey = surveyFinder.findByIdWithSectionsAndQuestions(id);
     return SurveyIntroGetResponse.of(survey, (userId != null), countQuestion(survey));
+  }
+
+  @Transactional(readOnly = true)
+  public SurveyGetResponse getSurveySection(final long surveyId, final int sectionOrder) {
+    return SurveyGetResponse.of(sectionFinder.findBySurveyIdAndSectionOrderWithQuestions(surveyId, sectionOrder), (int)sectionFinder.countBySurvey(surveyId));
   }
 
   private int countQuestion(final Survey survey) {

--- a/src/main/java/servnow/servnow/common/code/SectionErrorCode.java
+++ b/src/main/java/servnow/servnow/common/code/SectionErrorCode.java
@@ -1,0 +1,15 @@
+package servnow.servnow.common.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SectionErrorCode implements ErrorCode {
+
+  SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 섹션이 존재하지 않습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+}

--- a/src/main/java/servnow/servnow/domain/question/model/Question.java
+++ b/src/main/java/servnow/servnow/domain/question/model/Question.java
@@ -8,11 +8,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 import servnow.servnow.domain.common.BaseTimeEntity;
 import servnow.servnow.domain.multiplechoiceresult.model.MultipleChoiceResult;
 import servnow.servnow.domain.question.model.enums.QuestionType;
 import servnow.servnow.domain.section.model.Section;
-import servnow.servnow.domain.subjectiveresult.model.SubjectiveResult;
 
 @Entity
 @Getter
@@ -33,6 +33,9 @@ public class Question extends BaseTimeEntity {
     @Column(nullable = false)
     private int questionOrder;
 
+    @Column(nullable = false)
+    private String title;
+
     private String content;
 
     @Column(nullable = false)
@@ -49,15 +52,13 @@ public class Question extends BaseTimeEntity {
     private boolean hasNextSection;
 
     @OneToMany(mappedBy = "question")
+    @BatchSize(size = 100)
     private List<MultipleChoice> multipleChoices = new ArrayList<>();
-
-    @OneToOne(mappedBy = "question")
-    private SubjectiveResult subjectiveResults;
 
     @OneToMany(mappedBy = "question")
     private List<MultipleChoiceResult> multipleChoiceResults = new ArrayList<>();
 
-    public static Question create(Section section, int questionOrder, String content, QuestionType questionType, boolean isEssential, boolean isDuplicate, boolean hasNextSection){
-        return Question.builder().section(section).questionOrder(questionOrder).content(content).questionType(questionType).isEssential(isEssential).isDuplicate(isDuplicate).hasNextSection(hasNextSection).build();
+    public static Question create(Section section, int questionOrder, String title, String content, QuestionType questionType, boolean isEssential, boolean isDuplicate, boolean hasNextSection){
+        return Question.builder().section(section).questionOrder(questionOrder).title(title).content(content).questionType(questionType).isEssential(isEssential).isDuplicate(isDuplicate).hasNextSection(hasNextSection).build();
     }
 }

--- a/src/main/java/servnow/servnow/domain/section/repository/SectionRepository.java
+++ b/src/main/java/servnow/servnow/domain/section/repository/SectionRepository.java
@@ -1,8 +1,15 @@
 package servnow.servnow.domain.section.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import servnow.servnow.domain.section.model.Section;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
 
+  @Query("select s from Section s join fetch s.questions where s.survey.id = :surveyId and s.sectionOrder = :sectionOrder ")
+  Optional<Section> findBySurveyIdAndSectionOrderWithQuestions(@Param("surveyId") long surveyId, @Param("sectionOrder") int sectionOrder);
+
+  long countBySurveyId(long surveyId);
 }


### PR DESCRIPTION
-closes #13 

# 구현 내용❗️

# 요구사항 분석 ❗️

설문조사 조회 화면 API (섹션별)

### 작업 내용 1
- postman test 완료

```json
{
    "code": 200,
    "message": "요청이 성공했습니다(200).",
    "data": {
        "surveyId": 2,
        "sectionTitle": "섹션질문2",
        "sectionContent": "섹션설명2",
        "sectionOrder": 2,
        "sectionTotalCount": 2,
        "nextSectionNo": 3,
        "questions": [
            {
                "questionId": 8,
                "questionTitle": "질문제목3",
                "questionContent": "질문내용3",
                "questionOrder": 3,
                "questionType": "SUBJECTIVE_LONG",
                "isEssential": false,
                "isDuplicate": false,
                "hasNextSection": false,
                "answers": []
            },
            {
                "questionId": 9,
                "questionTitle": "질문제목4",
                "questionContent": "질문내용4",
                "questionOrder": 4,
                "questionType": "MULTIPLE_CHOICE",
                "isEssential": false,
                "isDuplicate": false,
                "hasNextSection": false,
                "answers": [
                    {
                        "answerContent": "1번문항",
                        "nextSectionNo": null
                    },
                    {
                        "answerContent": "2번문항",
                        "nextSectionNo": null
                    },
                    {
                        "answerContent": "3번문항",
                        "nextSectionNo": null
                    }
                ]
            }
        ]
    }
}
```



### 작업 내용 2

- 제가 question 엔티티에 title 필드를 빼먹어서 슬쩍 추가했습니다... 

# 구현 고민사항 ❗️

N/A
