### PR TITLE
[feat/#26] id/pw 찾기 api 구현

### DIFF
--- a/src/main/java/servnow/servnow/api/auth/controller/FindController.java
+++ b/src/main/java/servnow/servnow/api/auth/controller/FindController.java
@@ -1,23 +1,17 @@
 package servnow.servnow.api.auth.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import servnow.servnow.api.auth.service.FindInfoService;
 import servnow.servnow.api.dto.ServnowResponse;
 import servnow.servnow.api.dto.login.UserChangePwRequest;
-import servnow.servnow.api.result.service.ResultQueryService;
-import servnow.servnow.api.survey.service.SurveyQueryService;
 import servnow.servnow.api.user.dto.request.CertificationNumberRequest;
 import servnow.servnow.api.user.dto.request.EmailDuplicateRequest;
 import servnow.servnow.api.user.service.EmailService;
 import servnow.servnow.api.user.service.UserCommandService;
 import servnow.servnow.api.user.service.UserQueryService;
-import servnow.servnow.auth.UserId;
 import servnow.servnow.common.code.CommonSuccessCode;
-import servnow.servnow.common.code.LoginErrorCode;
 import servnow.servnow.common.code.UserErrorCode;
-import servnow.servnow.domain.user.model.UserInfo;
 import servnow.servnow.domain.user.repository.UserInfoRepository;
 
 @RestController
@@ -63,16 +57,12 @@ public class FindController {
     }
 
     @PostMapping("/change/pw")
-    public ServnowResponse<String> changePw(@RequestBody UserChangePwRequest request) throws Exception {
+    public ServnowResponse<Object> changePw(@RequestBody UserChangePwRequest request) throws Exception {
         assert request.password() != null;
-        if (check) {
-            if (request.password().equals(request.repassword())) {
-                String response = findInfoService.updatePassword(serialId, request.password());
 
-                return ServnowResponse.success(CommonSuccessCode.OK, response);
-            } else {
-                return ServnowResponse.fail(LoginErrorCode.PASSWORDS_DO_NOT_MATCH);
-            }
+        // 이메일 인증이 되었다면
+        if (check) {
+            return findInfoService.updatePassword(serialId, request.password(), request.repassword());
         } else {
             return ServnowResponse.fail(UserErrorCode.AUTHENTICATION_FAILED);
         }

--- a/src/main/java/servnow/servnow/api/auth/controller/FindController.java
+++ b/src/main/java/servnow/servnow/api/auth/controller/FindController.java
@@ -2,23 +2,79 @@ package servnow.servnow.api.auth.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import servnow.servnow.api.auth.service.FindInfoService;
 import servnow.servnow.api.dto.ServnowResponse;
+import servnow.servnow.api.dto.login.UserChangePwRequest;
+import servnow.servnow.api.result.service.ResultQueryService;
+import servnow.servnow.api.survey.service.SurveyQueryService;
+import servnow.servnow.api.user.dto.request.CertificationNumberRequest;
+import servnow.servnow.api.user.dto.request.EmailDuplicateRequest;
+import servnow.servnow.api.user.service.EmailService;
+import servnow.servnow.api.user.service.UserCommandService;
+import servnow.servnow.api.user.service.UserQueryService;
+import servnow.servnow.auth.UserId;
 import servnow.servnow.common.code.CommonSuccessCode;
+import servnow.servnow.common.code.LoginErrorCode;
+import servnow.servnow.common.code.UserErrorCode;
+import servnow.servnow.domain.user.model.UserInfo;
+import servnow.servnow.domain.user.repository.UserInfoRepository;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 public class FindController {
-    private FindInfoService findInfoService;
+    private final FindInfoService findInfoService;
 
-    @GetMapping("/auth/find/id")
-    public ServnowResponse<String> findId(Authentication authentication) {
-        String username = findInfoService.findSerialId(authentication);
+    private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
+    private final UserInfoRepository userInfoRepository;
 
-        return ServnowResponse.success(CommonSuccessCode.OK, username);
+    String serialId = null;
+    Boolean check = false;
+
+    /**
+     * db에 있는 email에 인증번호 전송
+     */
+    @PostMapping("/find/email-verify")
+    public ServnowResponse<String> verifyEmail(@RequestBody EmailDuplicateRequest request) throws Exception {
+        serialId = findInfoService.checkEmail(request.email());
+        return ServnowResponse.success(CommonSuccessCode.OK);
+    }
+
+    @PostMapping("/find/id")
+    public ServnowResponse<String> findId(@RequestBody CertificationNumberRequest request) {
+        if (request.certificationNumber().equals(EmailService.ePw)) {
+            return ServnowResponse.success(CommonSuccessCode.OK, serialId);
+        } else {
+            return ServnowResponse.fail(UserErrorCode.CERTIFICATION_NUMBER_MISMATCH);
+        }
+    }
+
+    @PostMapping("/find/pw")
+    public ServnowResponse<Boolean> findPw(@RequestBody CertificationNumberRequest request) {
+        if (request.certificationNumber().equals(EmailService.ePw)) {
+            check = true;
+            return ServnowResponse.success(CommonSuccessCode.OK);
+        } else {
+            check = false;
+            return ServnowResponse.fail(UserErrorCode.CERTIFICATION_NUMBER_MISMATCH);
+        }
+    }
+
+    @PostMapping("/change/pw")
+    public ServnowResponse<String> changePw(@RequestBody UserChangePwRequest request) throws Exception {
+        assert request.password() != null;
+        if (check) {
+            if (request.password().equals(request.repassword())) {
+                String response = findInfoService.updatePassword(serialId, request.password());
+
+                return ServnowResponse.success(CommonSuccessCode.OK, response);
+            } else {
+                return ServnowResponse.fail(LoginErrorCode.PASSWORDS_DO_NOT_MATCH);
+            }
+        } else {
+            return ServnowResponse.fail(UserErrorCode.AUTHENTICATION_FAILED);
+        }
     }
 }

--- a/src/main/java/servnow/servnow/api/auth/service/FindInfoService.java
+++ b/src/main/java/servnow/servnow/api/auth/service/FindInfoService.java
@@ -1,24 +1,71 @@
 package servnow.servnow.api.auth.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import servnow.servnow.api.dto.ServnowResponse;
+import servnow.servnow.api.user.service.EmailService;
+import servnow.servnow.common.code.CommonSuccessCode;
+import servnow.servnow.common.code.LoginErrorCode;
+import servnow.servnow.common.code.UserErrorCode;
+import servnow.servnow.domain.user.model.User;
 import servnow.servnow.domain.user.model.UserInfo;
 import servnow.servnow.domain.user.repository.UserInfoRepository;
+import servnow.servnow.domain.user.repository.UserRepository;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class FindInfoService {
 
+    private final UserRepository userRepository;
     private final UserInfoRepository userInfoRepository;
+    private final EmailService emailService;
+    private final PasswordEncoder passwordEncoder;
 
     /**
-     * 아이디 반환
+     * 이메일 존재 여부 확인
      */
-    public String findSerialId(Authentication authentication) {
-        String email = authentication.getName();
-        UserInfo userInfo = userInfoRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
-        return userInfo.getUser().getSerialId();
+     public String checkEmail(String email) throws Exception {
+        Optional<UserInfo> userInfo = userInfoRepository.findByEmail(email);
+        if (userInfo.isPresent()) {
+            String confirm = emailService.sendSimpleMessage(email);
+            String serialId = userInfo.get().getUser().getSerialId();
+
+            if (confirm.isEmpty()) {
+                return UserErrorCode.SEND_CERTIFICATION_NUMBER.getMessage();
+            } else {
+                return serialId;
+            }
+        } else {
+                return LoginErrorCode.USER_NOT_FOUND.getMessage();
+        }
     }
+
+
+    public String updatePassword(String serialId, String password) throws Exception {
+        User user = userRepository.findBySerialId(serialId)
+                .orElseThrow(() -> new Exception(LoginErrorCode.USER_NOT_FOUND.getMessage()));
+
+         if (isValidPassword(password)) {
+            String encodedPassword = passwordEncoder.encode(password);
+
+            user.setPassword(encodedPassword);
+            userRepository.save(user);
+
+            return CommonSuccessCode.OK.getMessage();
+         } else {
+                return LoginErrorCode.INVALID_PASSWORD_FORMAT.getMessage();
+         }
+
+    }
+
+    // 비밀번호 유효성 검증
+	private boolean isValidPassword(String password) {
+		String regex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*])[A-Za-z\\d!@#$%^&*]{8,20}$";
+		return password.matches(regex);
+	}
 }

--- a/src/main/java/servnow/servnow/api/auth/service/FindInfoService.java
+++ b/src/main/java/servnow/servnow/api/auth/service/FindInfoService.java
@@ -31,6 +31,7 @@ public class FindInfoService {
      */
      public String checkEmail(String email) throws Exception {
         Optional<UserInfo> userInfo = userInfoRepository.findByEmail(email);
+
         if (userInfo.isPresent()) {
             String confirm = emailService.sendSimpleMessage(email);
             String serialId = userInfo.get().getUser().getSerialId();

--- a/src/main/java/servnow/servnow/api/auth/service/FindInfoService.java
+++ b/src/main/java/servnow/servnow/api/auth/service/FindInfoService.java
@@ -46,21 +46,24 @@ public class FindInfoService {
     }
 
 
-    public String updatePassword(String serialId, String password) throws Exception {
+    public ServnowResponse<Object> updatePassword(String serialId, String password, String repassword) throws Exception {
         User user = userRepository.findBySerialId(serialId)
                 .orElseThrow(() -> new Exception(LoginErrorCode.USER_NOT_FOUND.getMessage()));
 
-         if (isValidPassword(password)) {
-            String encodedPassword = passwordEncoder.encode(password);
+        if (password.equals(repassword)) {
+            if (isValidPassword(password)) {
+                String encodedPassword = passwordEncoder.encode(password);
 
-            user.setPassword(encodedPassword);
-            userRepository.save(user);
+                user.setPassword(encodedPassword);
+                userRepository.save(user);
 
-            return CommonSuccessCode.OK.getMessage();
-         } else {
-                return LoginErrorCode.INVALID_PASSWORD_FORMAT.getMessage();
-         }
-
+                return ServnowResponse.success(CommonSuccessCode.OK);
+             } else {
+                return ServnowResponse.fail(LoginErrorCode.INVALID_PASSWORD_FORMAT);
+            }
+        } else {
+            return ServnowResponse.fail(LoginErrorCode.PASSWORDS_DO_NOT_MATCH);
+        }
     }
 
     // 비밀번호 유효성 검증

--- a/src/main/java/servnow/servnow/api/auth/service/LoginService.java
+++ b/src/main/java/servnow/servnow/api/auth/service/LoginService.java
@@ -3,6 +3,7 @@ package servnow.servnow.api.auth.service;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import servnow.servnow.api.dto.login.UserJoinRequest;
@@ -31,6 +32,8 @@ public class LoginService {
 	private final UserInfoRepository userInfoRepository;
 	private final JwtProvider jwtProvider;
 	private final UserInfoFinder userInfoFinder;
+    private final PasswordEncoder passwordEncoder;
+
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
 	// 일반 로그인
@@ -60,7 +63,8 @@ public class LoginService {
 		}
 
 		// 비밀번호 일치 확인
-		if (!request.password().equals(request.repassword())) {
+		String encodedPassword = passwordEncoder.encode(request.password());
+		if (!request.password().equals(request.repassword()) && !passwordEncoder.matches(request.password(), encodedPassword) ) {
 			throw new BadRequestException(LoginErrorCode.PASSWORDS_DO_NOT_MATCH);
 		}
 

--- a/src/main/java/servnow/servnow/api/dto/login/UserChangePwRequest.java
+++ b/src/main/java/servnow/servnow/api/dto/login/UserChangePwRequest.java
@@ -1,0 +1,11 @@
+package servnow.servnow.api.dto.login;
+
+import jakarta.annotation.Nullable;
+
+public record UserChangePwRequest (
+        @Nullable
+        String password,
+
+        @Nullable
+        String repassword
+){}

--- a/src/main/java/servnow/servnow/api/user/service/UserCommandService.java
+++ b/src/main/java/servnow/servnow/api/user/service/UserCommandService.java
@@ -1,6 +1,7 @@
 package servnow.servnow.api.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import servnow.servnow.api.user.dto.request.SaveEditProfilePageRequest;
 import servnow.servnow.common.code.UserErrorCode;
@@ -58,5 +59,4 @@ public class UserCommandService {
             userInfoRepository.save(userInfo);
         }
     }
-
 }

--- a/src/main/java/servnow/servnow/auth/config/SecurityConfig.java
+++ b/src/main/java/servnow/servnow/auth/config/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import servnow.servnow.auth.JwtAuthenticationEntryPoint;
@@ -24,7 +26,7 @@ public class SecurityConfig {
     private final JwtValidator jwtValidator;
     private final JwtProvider jwtProvider;
 
-   private static final String[] whiteList = { "/api/v1/auth/login", "/api/v1/auth/join", "/api/v1/auth/kakao", "/api/v1/find/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/api/v1/survey/*/intro"};
+   private static final String[] whiteList = { "/api/v1/auth/login", "/api/v1/auth/join", "/api/v1/auth/kakao", "/api/v1/find/**", "/api/v1/change/pw", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/api/v1/survey/*/intro"};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -50,5 +52,10 @@ public class SecurityConfig {
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring().requestMatchers(whiteList);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/servnow/servnow/common/code/LoginErrorCode.java
+++ b/src/main/java/servnow/servnow/common/code/LoginErrorCode.java
@@ -20,7 +20,8 @@ public enum LoginErrorCode implements ErrorCode {
   USERNAME_TOO_SHORT(HttpStatus.BAD_REQUEST, "아이디가 너무 짧습니다."),
   INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 8~20자, 영문, 숫자, 특수문자 혼합으로 입력해주세요."),
   INVALID_BIRTHDATE(HttpStatus.BAD_REQUEST, "유효하지 않은 생년월일입니다."),
-  MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "필수 항목이 누락되었습니다.");
+  MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "필수 항목이 누락되었습니다."),
+  INVALID_PW_KAKAO_USER(HttpStatus.BAD_REQUEST, "카카오 계정은 비밀번호를 변경할 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/servnow/servnow/common/code/UserErrorCode.java
+++ b/src/main/java/servnow/servnow/common/code/UserErrorCode.java
@@ -16,6 +16,7 @@ public enum UserErrorCode implements ErrorCode {
     EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "해당 이메일은 이미 사용 중입니다."),
     SEND_CERTIFICATION_NUMBER(HttpStatus.BAD_REQUEST, "인증번호 전송을 실패하였습니다."),
     CERTIFICATION_NUMBER_MISMATCH(HttpStatus.UNAUTHORIZED, "인증번호가 일치하지 않습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증이 진행되지 않았습니다."),
 
             ;
 


### PR DESCRIPTION
-closes #26

# 구현 내용❗️
<img width="127" alt="image" src="https://github.com/user-attachments/assets/b94927d7-a137-489b-8463-e7df8f75b4f5">

- 이메일 인증 후 id 찾기, pw 변경 기능을 구현하였습니다. 

### 작업 내용 1
<img width="320" alt="image" src="https://github.com/user-attachments/assets/fa728b59-ddac-4a30-b3cf-1bdb3307aee6">

- db에 있는 email만 본인 인증이 가능합니다.
- 이때 카카오 플랫폼을 이용한 사용자는 비밀번호 변경이 불가합니다.
- 없을 경우 사용자를 찾을 수 없다는 에러 코드를 띄웁니다.

### 작업 내용 2
<img width="357" alt="image" src="https://github.com/user-attachments/assets/6832b75c-a933-4ab7-a89a-051ca7935169">

<img width="317" alt="image" src="https://github.com/user-attachments/assets/3c5ae460-7547-4f04-a8db-6eaa38eb1024">

<img width="312" alt="image" src="https://github.com/user-attachments/assets/f7c58d69-5b51-4e30-960b-0b3a34dbf71a">


