### PR TITLE
[feat/#26] 회원가입 이메일 인증 api 구현

### DIFF
--- a/src/main/java/servnow/servnow/api/auth/controller/LoginController.java
+++ b/src/main/java/servnow/servnow/api/auth/controller/LoginController.java
@@ -56,7 +56,7 @@ public class LoginController {
 
     // 일반 회원가입
     @PostMapping("/auth/join")
-	public ServnowResponse<String> join(@RequestBody UserJoinRequest request) {
+	public ServnowResponse<String> join(@RequestBody UserJoinRequest request) throws Exception {
          if (request.email() != null && !request.email().isEmpty() &&
                 request.certificationNumber() != null && request.certificationNumber().equals(EmailService.ePw)) {
         		loginService.join(request);
@@ -69,18 +69,8 @@ public class LoginController {
 
     // 회원가입 - 이메일 인증
     @PostMapping("/auth/join/identity-verification")
-    public ServnowResponse<Void> identityVerification(@RequestBody EmailDuplicateRequest request) throws Exception {
+    public ServnowResponse<Void> identityVerification(@RequestBody UserJoinRequest request) throws Exception {
         return userQueryService.identityVerification(request.email());
-    }
-
-    // 회원가입 - 이메일 인증 번호 확인
-    @PostMapping("/auth/join/certification")
-    public ServnowResponse<Object> CertificationNumber(@RequestBody CertificationNumberRequest request) {
-        if (request.certificationNumber().equals(EmailService.ePw)) {
-            return ServnowResponse.success(CommonSuccessCode.OK);
-        } else {
-            return ServnowResponse.fail(UserErrorCode.CERTIFICATION_NUMBER_MISMATCH);
-        }
     }
 
   @PostMapping("/auth/reissue")

--- a/src/main/java/servnow/servnow/api/auth/controller/LoginController.java
+++ b/src/main/java/servnow/servnow/api/auth/controller/LoginController.java
@@ -62,7 +62,6 @@ public class LoginController {
         		loginService.join(request);
 	        	return ServnowResponse.success(CommonSuccessCode.OK, "회원가입이 완료되었습니다.");
         } else {
-            System.out.println("Controller out");
             return ServnowResponse.fail(UserErrorCode.CERTIFICATION_NUMBER_MISMATCH);
         }
 	}

--- a/src/main/java/servnow/servnow/api/auth/service/LoginService.java
+++ b/src/main/java/servnow/servnow/api/auth/service/LoginService.java
@@ -20,6 +20,7 @@ import servnow.servnow.common.exception.BadRequestException;
 import servnow.servnow.common.exception.UnauthorizedException;
 import servnow.servnow.domain.user.model.User;
 import servnow.servnow.domain.user.model.UserInfo;
+import servnow.servnow.domain.user.model.enums.Gender;
 import servnow.servnow.domain.user.model.enums.Platform;
 import servnow.servnow.domain.user.repository.UserInfoRepository;
 import servnow.servnow.domain.user.repository.UserRepository;
@@ -89,6 +90,12 @@ public class LoginService {
 			throw new BadRequestException(LoginErrorCode.INVALID_EMAIL_FORMAT);
 		}
 
+		// 이메일 중복 확인
+		Optional<UserInfo> existingUserInfo = userInfoRepository.findByEmail(request.email());
+		if (existingUserInfo.isPresent()) {
+			throw new BadRequestException(LoginErrorCode.ALREADY_EXISTED_EMAIL);
+		}
+
 		// 필수 정보 확인
 		if (!isUserInfoValid(request)) {
 			throw new BadRequestException(LoginErrorCode.MISSING_REQUIRED_FIELD);
@@ -99,8 +106,11 @@ public class LoginService {
 
 		userRepository.save(newUser);
 
+		System.out.println(request.gender());
+		Gender gender = Gender.getEnumGenderFromStringGender(request.gender());
+
 		UserInfo newUserInfo = UserInfo.createMemberInfo(
-				newUser, request.nickname(), request.gender(), request.email(), LocalDate.now(), null, null);
+				newUser, request.nickname(), gender, request.email(), LocalDate.now(), null, null);
 		userInfoRepository.save(newUserInfo);
 	}
 

--- a/src/main/java/servnow/servnow/api/dto/login/UserJoinRequest.java
+++ b/src/main/java/servnow/servnow/api/dto/login/UserJoinRequest.java
@@ -14,6 +14,8 @@ public record UserJoinRequest(
         @Nullable
         String email,
         @Nullable
+        String certificationNumber,
+        @Nullable
         String nickname,
         @Nullable
         String gender,

--- a/src/main/java/servnow/servnow/api/user/service/UserFinder.java
+++ b/src/main/java/servnow/servnow/api/user/service/UserFinder.java
@@ -33,6 +33,7 @@ public class UserFinder {
                 ACTIVE);
     }
     public Optional<User> findUserByPlatFormAndSeralId(final Platform platform, final String serialId) {
+      System.out.println("kkkkkk");
         return userRepository.findByPlatformAndSerialId(platform, serialId);
     }
 }

--- a/src/main/java/servnow/servnow/auth/config/SecurityConfig.java
+++ b/src/main/java/servnow/servnow/auth/config/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
     private final JwtValidator jwtValidator;
     private final JwtProvider jwtProvider;
 
-    private static final String[] whiteList = { "/api/v1/auth/login", "/api/v1/auth/join", "/api/v1/auth/kakao", "/api/v1/find/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/api/v1/survey/guest/**", "/api/v1/survey/home", "api/v1/result/guest/**",  "/api/v1/change/pw", "/api/v1/auth/reissue"};
+    private static final String[] whiteList = { "/api/v1/auth/**", "/api/v1/auth/join", "/api/v1/auth/kakao", "/api/v1/find/**", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**", "/api/v1/survey/guest/**", "/api/v1/survey/home", "api/v1/result/guest/**",  "/api/v1/change/pw", "/api/v1/auth/reissue"};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/servnow/servnow/common/code/LoginErrorCode.java
+++ b/src/main/java/servnow/servnow/common/code/LoginErrorCode.java
@@ -17,11 +17,16 @@ public enum LoginErrorCode implements ErrorCode {
   USER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),
   PASSWORDS_DO_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
   INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "이메일 형식이 적합하지 않습니다."),
+  ALREADY_EXISTED_EMAIL(HttpStatus.BAD_REQUEST, "이메일 형식이 적합하지 않습니다."),
   USERNAME_TOO_SHORT(HttpStatus.BAD_REQUEST, "아이디가 너무 짧습니다."),
   INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "비밀번호는 8~20자, 영문, 숫자, 특수문자 혼합으로 입력해주세요."),
   INVALID_BIRTHDATE(HttpStatus.BAD_REQUEST, "유효하지 않은 생년월일입니다."),
   MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "필수 항목이 누락되었습니다."),
-  INVALID_PW_KAKAO_USER(HttpStatus.BAD_REQUEST, "카카오 계정은 비밀번호를 변경할 수 없습니다.");
+  INVALID_PW_KAKAO_USER(HttpStatus.BAD_REQUEST, "카카오 계정은 비밀번호를 변경할 수 없습니다."),
+  INVALID_GENDER_TYPE(HttpStatus.BAD_REQUEST, "성별 타입이 올바르지 않습니다.")
+
+  ,
+  ;
 
   private final HttpStatus httpStatus;
   private final String message;

--- a/src/main/java/servnow/servnow/domain/user/model/User.java
+++ b/src/main/java/servnow/servnow/domain/user/model/User.java
@@ -67,7 +67,7 @@ public class User extends BaseTimeEntity {
     }
 
     public static User createUser(final String serialId, final Platform platform) {
-        System.out.println("ㅇㅇㅇ");
+        System.out.println("hi");
         return User.builder()
                 .serialId(serialId)
                 .platform(platform)

--- a/src/main/java/servnow/servnow/domain/user/model/UserInfo.java
+++ b/src/main/java/servnow/servnow/domain/user/model/UserInfo.java
@@ -55,7 +55,7 @@ public class UserInfo extends BaseTimeEntity {
     public static UserInfo createMemberInfo(
             final User user,
             final String nickname,
-            final String gender,
+            final Gender gender,
             final String email,
             final LocalDate birthDate,
             final String refreshToken,
@@ -68,7 +68,7 @@ public class UserInfo extends BaseTimeEntity {
                 .birth(birthDate)
                 .email(email)
                 .profile_url(profile_url)
-                .gender(Gender.valueOf(gender))
+                .gender(gender)
                 .point(0)
                 .level(Level.COMMONER)
                 .build();

--- a/src/main/java/servnow/servnow/domain/user/model/enums/Gender.java
+++ b/src/main/java/servnow/servnow/domain/user/model/enums/Gender.java
@@ -3,6 +3,7 @@ package servnow.servnow.domain.user.model.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import servnow.servnow.common.code.AuthErrorCode;
+import servnow.servnow.common.code.LoginErrorCode;
 import servnow.servnow.common.exception.BadRequestException;
 
 import java.util.Arrays;
@@ -11,15 +12,15 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum Gender {
 
-  MALE("male"),
-  FEMALE("female");
+  MALE("MALE"),
+  FEMALE("FEMALE");
 
   private final String value;
 
   public static Gender getEnumGenderFromStringGender(String loginGender) {
     return Arrays.stream(values())
-        .filter(gender -> gender.value.equals(loginGender))
+        .filter(gender -> gender.value.equals(loginGender.toUpperCase()))
         .findFirst()
-        .orElseThrow(() -> new BadRequestException(AuthErrorCode.valueOf("ERROR")));
+        .orElseThrow(() -> new BadRequestException(LoginErrorCode.INVALID_GENDER_TYPE));
   }
 }


### PR DESCRIPTION
-closes #26  

# 구현 내용❗️
- 회원가입 때 필요한 이메일 인증은 토큰이 없어야 한다는 점이 뒤늦게 생각나서. . 회원가입: 이메일 인증 구현하였습니다.