### PR TITLE
[feat/#78] USER_INFO_NOT_FOUND 에러 추가

### DIFF
--- a/src/main/java/servnow/servnow/api/user/service/UserQueryService.java
+++ b/src/main/java/servnow/servnow/api/user/service/UserQueryService.java
@@ -33,7 +33,7 @@ public class UserQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
         UserInfo userinfo = userInfoRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_INFO_NOT_FOUND));
         return MyPageResponse.of(userinfo, user);
     }
 

--- a/src/main/java/servnow/servnow/common/code/UserErrorCode.java
+++ b/src/main/java/servnow/servnow/common/code/UserErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다."),
+    USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저가 존재하지 않습니다.(1)"),
     PLATFORM_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 플랫폼은 존재하지 않습니다."),
     WRONG_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호 입력 칸을 비워주세요."),
     DUPLICATE_SERIAL_ID(HttpStatus.BAD_REQUEST, "이미 존재하는 아이디 입니다."),


### PR DESCRIPTION
-closes #78

# 구현 내용❗️
UserInfo에서의 에러처리를 User의 에러처리를 다르게 변경

# 요구사항 분석 ❗️

### 작업 내용 1
```
    @Transactional(readOnly = true)
    public MyPageResponse getMyPage(final Long userId) {
        User user = userRepository.findById(userId)
                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
        UserInfo userinfo = userInfoRepository.findById(userId)
                .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_INFO_NOT_FOUND));
        return MyPageResponse.of(userinfo, user);
    }
```

### 작업 내용 2
...

# 구현 고민사항 ❗️

<!-- 이 부분은 코드를 직접 올려주면 다른 리뷰어들에게 도움이 될 것 같습니다. -->

### 고민사항 1
상세설명

### 고민사항 2
상세설명

...
