### PR TITLE
[hotfix/#78] userInfoRepository에서 유저 조회에 사용하는 jpa 함수 변경 및 에러 원인 설명

### DIFF
--- a/src/main/java/servnow/servnow/api/user/service/UserQueryService.java
+++ b/src/main/java/servnow/servnow/api/user/service/UserQueryService.java
@@ -32,7 +32,7 @@ public class UserQueryService {
     public MyPageResponse getMyPage(final Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
-        UserInfo userinfo = userInfoRepository.findById(userId)
+        UserInfo userinfo = userInfoRepository.findByUserId(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_INFO_NOT_FOUND));
         return MyPageResponse.of(userinfo, user);
     }


### PR DESCRIPTION
-closes #78

# 구현 내용❗️
userInfoRepository에서 유저 조회에 사용하는 jpa 함수를 변경

# 요구사항 분석 ❗️
```
Hibernate: select ui1_0.user_info_id,ui1_0.birth,ui1_0.created_at,ui1_0.email,ui1_0.gender,ui1_0.level,ui1_0.nickname,ui1_0.point,ui1_0.profile_url,ui1_0.refresh_token,ui1_0.updated_at,ui1_0.user_id from user_info ui1_0 where ui1_0.user_id=?
Hibernate: update user_info set birth=?,email=?,gender=?,level=?,nickname=?,point=?,profile_url=?,refresh_token=?,updated_at=?,user_id=? where user_info_id=?
Hibernate: select u1_0.user_id,u1_0.created_at,u1_0.deleted_at,u1_0.password,u1_0.platform,u1_0.serial_id,u1_0.status,u1_0.updated_at,u1_0.user_role from users u1_0 where u1_0.user_id=?
Hibernate: select ui1_0.user_info_id,ui1_0.birth,ui1_0.created_at,ui1_0.email,ui1_0.gender,ui1_0.level,ui1_0.nickname,ui1_0.point,ui1_0.profile_url,ui1_0.refresh_token,ui1_0.updated_at,ui1_0.user_id from user_info ui1_0 where ui1_0.user_info_id=?
2024-08-21T15:01:58.805+09:00 ERROR 1 --- [nio-8080-exec-4] s.s.api.advice.GlobalExceptionHandler    : handleEntityNotFoundException() in GlobalExceptionHandler throw EntityNotFoundException : 해당 유저가 존재하지 않습니다.(1)
```
위와 같은 로그를 통해 UserInfo를 찾을 때 user_info_id로 조회하고 있는 것을 알 수 있고 실제로는 user_id로 조회해야 합니다

### 작업 내용 1
**기존 코드**
```
UserInfo userinfo = userInfoRepository.findById(userId)
            .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
```

**변경 코드**
```
 UserInfo userinfo = userInfoRepository.findByUserId(userId)
            .orElseThrow(() -> new NotFoundException(UserInfoErrorCode.USER_INFO_NOT_FOUND));
```
**UserInfoRepository에 추가한 코드**
```
public interface UserInfoRepository extends JpaRepository<UserInfo, Long> {
    Optional<UserInfo> findByUserId(Long userId);
}
```

**에러가 발생한 이유**
UserInfo 엔티티 클래스에서 user_info_id가 기본 키(@Id로 선언된 필드)로 설정되어 있으므로 findById 메서드는 자동으로 user_info_id를 사용해 데이터를 조회하게 됩니다
따라서 user_id로 조회하기 위해서는 findById 메서드 대신 userId를 이용해 조회할 수 있는 별도의 메서드를 리포지토리에 정의해야 합니다. 그렇기 때문에 UserInfoRepository에 findByUserId 메소드를 정의하였습니다.

