### PR TITLE
[feat/#83] 메모장 조회에 메모별 id값 추가

### DIFF
--- a/src/main/java/servnow/servnow/api/result/dto/response/MySurveysResultMemoResponse.java
+++ b/src/main/java/servnow/servnow/api/result/dto/response/MySurveysResultMemoResponse.java
@@ -2,6 +2,7 @@ package servnow.servnow.api.result.dto.response;
 
 
 import java.util.List;
+import java.util.Map;
 
 public record MySurveysResultMemoResponse(
         List<QuestionMemo> questions
@@ -10,7 +11,8 @@ public record MySurveysResultMemoResponse(
             Long questionId,
             int questionOrder,
             String title,
-            List<String> memos
+//            List<String> memos,
+            List<Map<Long, String>> memos
     ) {}
 }
 

--- a/src/main/java/servnow/servnow/api/result/service/ResultQueryService.java
+++ b/src/main/java/servnow/servnow/api/result/service/ResultQueryService.java
@@ -136,19 +136,19 @@ public class ResultQueryService {
                 .flatMap(section -> section.getQuestions().stream())
                 .toList();
 
-        Map<Long, List<String>> memosByQuestionId = questions.stream()
-                .flatMap(question -> question.getSurveyResultMemos().stream())
-                .collect(Collectors.groupingBy(
-                        memo -> memo.getQuestion().getId(),
-                        Collectors.mapping(SurveyResultMemo::getContent, Collectors.toList())
-                ));
-
         List<MySurveysResultMemoResponse.QuestionMemo> questionMemos = questions.stream()
                 .map(question -> new MySurveysResultMemoResponse.QuestionMemo(
                         question.getId(),
                         question.getQuestionOrder(),
                         question.getTitle(),
-                        memosByQuestionId.getOrDefault(question.getId(), new ArrayList<>())
+                        question.getSurveyResultMemos().stream()
+                                .collect(Collectors.groupingBy(
+                                        SurveyResultMemo::getId,
+                                        Collectors.mapping(SurveyResultMemo::getContent, Collectors.toList())
+                                ))
+                                .entrySet().stream()
+                                .map(entry -> Map.of(entry.getKey(), entry.getValue().get(0)))
+                                .collect(Collectors.toList())
                 ))
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
-closes #83 

# 구현 내용❗️
```
{
    "code": 200,
    "message": "요청이 성공했습니다(200).",
    "data": {
        "questions": [
            {
                "questionId": 1,
                "questionOrder": 1,
                "title": "사과 포도에 대한 title",
                "memos": [
                    {
                        "34": "Memo 1 for Question 1"
                    },
                    {
                        "35": "Memo 2 for Question 1"
                    }
                ]
            },
            {
                "questionId": 2,
                "questionOrder": 2,
                "title": "모두 고르는 질문 title",
                "memos": [
                    {
                        "36": "Memo 1 for Question 2"
                    },
                    {
                        "37": "Memo 2 for Question 2"
                    },
                    {
                        "38": "Memo 3 for Question 2"
                    }
                ]
            },
            {
                "questionId": 3,
                "questionOrder": 3,
                "title": "주관식 질문 title",
                "memos": []
            },
            {
                "questionId": 4,
                "questionOrder": 4,
                "title": "마지막 객관식 title",
                "memos": []
            }
        ]
    }
}
```

# 요구사항 분석 ❗️
메모별로 id 값을 반환한다.

### 작업 내용 1
메모별 id값을 메모 내용과 묶어서 반환

### 작업 내용 2
...

# 구현 고민사항 ❗️

<!-- 이 부분은 코드를 직접 올려주면 다른 리뷰어들에게 도움이 될 것 같습니다. -->

### 고민사항 1
상세설명

### 고민사항 2
상세설명

...
