### PR TITLE
[fix/88] 마이페이지 내가 제작한 설문지 목록 조회에 종료 일자 추가 #88

### DIFF
--- a/src/main/java/servnow/servnow/api/user/dto/response/MySurveyResponse.java
+++ b/src/main/java/servnow/servnow/api/user/dto/response/MySurveyResponse.java
@@ -10,6 +10,7 @@ public record MySurveyResponse(
         CharacterType characterType,
         String title,
         LocalDateTime createdAt,
+        LocalDateTime expiredAt,
         int entry
 
 ) {
@@ -19,6 +20,7 @@ public record MySurveyResponse(
                 survey.getCharacterType(),
                 survey.getTitle(),
                 survey.getCreatedAt(),
+                survey.getExpiredAt(),
                 survey.getSurveyResults().size()
         );
     }


### PR DESCRIPTION
-closes #88

# 구현 내용❗️
마이페이지 내가 제작한 설문지 목록 조회에 종료 일자 추가 
```
{
    "code": 200,
    "message": "요청이 성공했습니다(200).",
    "data": [
        {
            "surveyId": 1,
            "characterType": "TYPE_TWO",
            "title": "어떤 과일이 가장 좋은가요?",
            "createdAt": "2024-08-19T17:42:05.545587",
            "expiredAt": "2024-08-26T17:42:05.545587",
            "entry": 1
        }
    ]
}
```
# 요구사항 분석 ❗️

### 작업 내용 1
종료 일자 추가

### 작업 내용 2
...

# 구현 고민사항 ❗️

<!-- 이 부분은 코드를 직접 올려주면 다른 리뷰어들에게 도움이 될 것 같습니다. -->

### 고민사항 1
상세설명

### 고민사항 2
상세설명

...
