### PR TITLE
[feat/#93] 메모 삭제 API 구현

### DIFF
--- a/src/main/java/servnow/servnow/api/result/service/ResultCommandService.java
+++ b/src/main/java/servnow/servnow/api/result/service/ResultCommandService.java
@@ -1,10 +1,12 @@
 package servnow.servnow.api.result.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import servnow.servnow.api.result.dto.request.MySurveysResultMemoRequest;
 import servnow.servnow.api.result.dto.request.ResultPostRequest;
+import servnow.servnow.api.result.service.surveyresultmemo.SurveyResultMemoFinder;
+import servnow.servnow.api.result.service.surveyresultmemo.SurveyResultMemoUpdater;
 import servnow.servnow.api.user.service.UserFinder;
 import servnow.servnow.api.user.service.UserInfoFinder;
 import servnow.servnow.api.user.service.UserInfoUpdater;
@@ -46,6 +48,8 @@ public class ResultCommandService {
     private final MultipleChoiceResultUpdater multipleChoiceResultUpdater;
     private final SurveyResultRepository surveyResultRepository;
     private final SurveyResultMemoRepository surveyResultMemoRepository;
+    private final SurveyResultMemoFinder surveyResultMemoFinder;
+    private final SurveyResultMemoUpdater surveyResultMemoUpdater;
 
     @Transactional
     public void createResult(final long userId, final ResultPostRequest resultPostRequest, final long surveyId) {
@@ -136,4 +140,8 @@ public class ResultCommandService {
         }
     }
 
+    @Transactional
+    public void deleteSurveyMemo(final long id) {
+        surveyResultMemoUpdater.deleteById(surveyResultMemoFinder.findById(id).getId());
+    }
 }

--- a/src/main/java/servnow/servnow/api/result/service/surveyresultmemo/SurveyResultMemoFinder.java
+++ b/src/main/java/servnow/servnow/api/result/service/surveyresultmemo/SurveyResultMemoFinder.java
@@ -1,0 +1,20 @@
+package servnow.servnow.api.result.service.surveyresultmemo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import servnow.servnow.common.code.SurveyResultMemoErrorCode;
+import servnow.servnow.common.exception.NotFoundException;
+import servnow.servnow.domain.surveyresultmemo.model.SurveyResultMemo;
+import servnow.servnow.domain.surveyresultmemo.repository.SurveyResultMemoRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SurveyResultMemoFinder {
+
+  private final SurveyResultMemoRepository surveyResultMemoRepository;
+
+  public SurveyResultMemo findById(final long id) {
+      return surveyResultMemoRepository.findById(id).orElseThrow(
+          () -> new NotFoundException(SurveyResultMemoErrorCode.SURVEY_RESULT_MEMO_NOT_FOUND));
+  }
+}

--- a/src/main/java/servnow/servnow/api/result/service/surveyresultmemo/SurveyResultMemoUpdater.java
+++ b/src/main/java/servnow/servnow/api/result/service/surveyresultmemo/SurveyResultMemoUpdater.java
@@ -1,0 +1,16 @@
+package servnow.servnow.api.result.service.surveyresultmemo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import servnow.servnow.domain.surveyresultmemo.repository.SurveyResultMemoRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SurveyResultMemoUpdater {
+
+  private final SurveyResultMemoRepository surveyResultMemoRepository;
+
+  public void deleteById(final long id) {
+    surveyResultMemoRepository.deleteById(id);
+  }
+}

--- a/src/main/java/servnow/servnow/api/user/controller/UserController.java
+++ b/src/main/java/servnow/servnow/api/user/controller/UserController.java
@@ -120,4 +120,10 @@ public class UserController {
     public ServnowResponse<UserPointGetResponse> getUserPoint(@Parameter(hidden = true) @UserId final Long userId) {
         return ServnowResponse.success(CommonSuccessCode.OK, userQueryService.getUserPoint(userId));
     }
+
+    @DeleteMapping("/users/me/survey/{id}/memo")
+    public ServnowResponse<Void> deleteSurveyMemo(@PathVariable(name = "id") Long id) {
+        resultCommandService.deleteSurveyMemo(id);
+        return ServnowResponse.success(CommonSuccessCode.OK);
+    }
 }

--- a/src/main/java/servnow/servnow/api/user/service/UserCommandService.java
+++ b/src/main/java/servnow/servnow/api/user/service/UserCommandService.java
@@ -1,8 +1,10 @@
 package servnow.servnow.api.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import servnow.servnow.api.result.service.surveyresultmemo.SurveyResultMemoFinder;
+import servnow.servnow.api.result.service.surveyresultmemo.SurveyResultMemoUpdater;
 import servnow.servnow.api.user.dto.request.SaveEditProfilePageRequest;
 import servnow.servnow.common.code.UserErrorCode;
 import servnow.servnow.common.code.UserInfoErrorCode;
@@ -20,6 +22,9 @@ public class UserCommandService {
     private final UserInfoRepository userInfoRepository;
     private final UserRepository userRepository;
     private final UserInfoFinder userInfoFinder;
+    private final SurveyResultMemoFinder surveyResultMemoFinder;
+    private final SurveyResultMemoUpdater surveyResultMemoUpdater;
+
     public void profileSave(final Long userId, SaveEditProfilePageRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(UserErrorCode.USER_NOT_FOUND));
@@ -58,5 +63,10 @@ public class UserCommandService {
             userInfo.setEmail(request.email());
             userInfoRepository.save(userInfo);
         }
+    }
+
+    @Transactional
+    public void deleteSurveyMemo(final long id) {
+        surveyResultMemoUpdater.deleteById(surveyResultMemoFinder.findById(id).getId());
     }
 }

--- a/src/main/java/servnow/servnow/api/user/service/UserCommandService.java
+++ b/src/main/java/servnow/servnow/api/user/service/UserCommandService.java
@@ -22,8 +22,6 @@ public class UserCommandService {
     private final UserInfoRepository userInfoRepository;
     private final UserRepository userRepository;
     private final UserInfoFinder userInfoFinder;
-    private final SurveyResultMemoFinder surveyResultMemoFinder;
-    private final SurveyResultMemoUpdater surveyResultMemoUpdater;
 
     public void profileSave(final Long userId, SaveEditProfilePageRequest request) {
         User user = userRepository.findById(userId)
@@ -63,10 +61,5 @@ public class UserCommandService {
             userInfo.setEmail(request.email());
             userInfoRepository.save(userInfo);
         }
-    }
-
-    @Transactional
-    public void deleteSurveyMemo(final long id) {
-        surveyResultMemoUpdater.deleteById(surveyResultMemoFinder.findById(id).getId());
     }
 }

--- a/src/main/java/servnow/servnow/common/code/SurveyResultMemoErrorCode.java
+++ b/src/main/java/servnow/servnow/common/code/SurveyResultMemoErrorCode.java
@@ -1,0 +1,15 @@
+package servnow.servnow.common.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SurveyResultMemoErrorCode implements ErrorCode{
+
+  SURVEY_RESULT_MEMO_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메모가 존재하지 않습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String message;
+}


### PR DESCRIPTION
-closes #93  

# 구현 내용❗️

# 요구사항 분석 ❗️

### 작업 내용 1
메모 삭제 API를 구현했습니다.
스웨거 
및 로컬 DB에서 테스트 완료

<img width="748" alt="스크린샷 2024-08-22 오전 10 02 15" src="https://github.com/user-attachments/assets/52a0cf70-a569-4d21-8854-dfc5372c6a91">

# 구현 고민사항 ❗️

N/A